### PR TITLE
feat: centralized utils.js for web frontend

### DIFF
--- a/static/js/map_ft.js
+++ b/static/js/map_ft.js
@@ -21,54 +21,6 @@
  * - GeoJSON data files (countries, continents, CQ zones, ITU zones)
  */
 
-// Global arrays to store GeoJSON feature collections for geographic lookups
-// These are loaded asynchronously on page load
-let countryFeat = [];      // Country boundary polygons (~250 countries)
-let continentFeat = [];    // Continent boundary polygons (7 continents)
-let cqZoneFeat = [];       // CQ zone polygons (40 zones for amateur radio contests)
-let ITUZoneFeat = [];      // ITU zone polygons (90 zones for telecommunications)
-
-
-
-/**
- * Load country boundary polygons from GeoJSON file.
- *
- * Fetches the countries.geojson file (14MB) containing boundary polygons
- * for all world countries. Used for country-based filtering.
- *
- * @async
- * @returns {Promise<void>}
- */
-async function loadCountryPolygons() {
-  try {
-    const res = await fetch("js/countries.geojson");
-    const data = await res.json();
-    countryFeat = data.features;
-    console.log("Loaded", countryFeat.length, "country polygons");
-  } catch (err) {
-    console.error("Failed to load countries.geojson", err);
-  }
-}
-
-/**
- * Load continent boundary polygons from GeoJSON file.
- *
- * Fetches the continents.geojson file (4KB) containing polygons for
- * the 7 continents. Used for continent-based filtering.
- *
- * @async
- * @returns {Promise<void>}
- */
-async function loadContinentPolygons() {
-  try {
-    const res = await fetch("js/continents.geojson");
-    const data = await res.json();
-    continentFeat = data.features;
-    console.log("Loaded", continentFeat.length, "continent polygons")
-  } catch (e) {
-    console.error("Failed to load continent GeoJSON", e);
-  }
-}
 // async function loadCqZones() {
 //   try {
 //     const res = await fetch("js/cqzones.geojson");
@@ -148,16 +100,6 @@ async function loadContinentPolygons() {
   }
 
 
-async function loadITUZones() {
-  try {
-    const res = await fetch("js/ituzones.geojson");
-    const data = await res.json();
-    ITUZoneFeat = data.features;
-    console.log("Loaded", ITUZoneFeat.length, "ITU Zones");
-  } catch (e) {
-    console.error("Failed to load ITU Zones", e);
-  }
-}
 // generate cq-zones select
 const select1 = document.getElementById("cqZoneFilter");
 
@@ -175,104 +117,6 @@ for (let i = 1; i <= 90; i++) {
   opt.textContent = i;
   select2.appendChild(opt);
 }
-/**
- * Lookup country name from geographic coordinates.
- *
- * Uses Turf.js point-in-polygon test against country boundary polygons
- * to determine which country contains the given coordinates.
- *
- * @param {number} lat - Latitude in decimal degrees
- * @param {number} lon - Longitude in decimal degrees
- * @returns {string} Country name or "Unknown" if not found
- *
- * @example
- * lookupCountry(40.7128, -74.0060) // "United States of America"
- */
-function lookupCountry(lat, lon) {
-  const pt = turf.point([lon, lat]);
-  for (const feature of countryFeat) {
-    if (turf.booleanPointInPolygon(pt, feature)) {
-      return feature.properties.name || "Unknown";
-    }
-  }
-  return "Unknown";
-}
-
-/**
- * Lookup continent name from geographic coordinates.
- *
- * @param {number} lat - Latitude in decimal degrees
- * @param {number} lon - Longitude in decimal degrees
- * @returns {string|null} Continent name or null if not found
- *
- * @example
- * lookupContinent(40.7128, -74.0060) // "North America"
- */
-function lookupContinent(lat, lon) {
-  const pt = turf.point([lon, lat]);
-  for (const feature of continentFeat) {
-    if (turf.booleanPointInPolygon(pt, feature)) {
-      return feature.properties.continent || "Unknown";
-    }
-  }
-  return null;
-}
-
-/**
- * Lookup CQ zone number from geographic coordinates.
- *
- * CQ zones are numbered 1-40 and are used for amateur radio
- * contests and awards (e.g., Worked All Zones - WAZ).
- *
- * @param {number} lat - Latitude in decimal degrees
- * @param {number} lon - Longitude in decimal degrees
- * @returns {string} CQ zone number (1-40) or "Unknown"
- *
- * @example
- * lookupCqZone(40.7128, -74.0060) // "5" (New York is in CQ zone 5)
- */
-function lookupCqZone(lat, lon) {
-  const pt = turf.point([lon, lat]);
-  for (const feature of cqZoneFeat) {
-    if (turf.booleanPointInPolygon(pt, feature)) {
-      return String(feature.properties.cq_zone_number);
-    }
-  }
-  return "Unknown";
-}
-
-/**
- * Lookup ITU zone number from geographic coordinates.
- *
- * ITU zones are numbered 1-90 and are defined by the International
- * Telecommunication Union for amateur radio purposes.
- *
- * @param {number} lat - Latitude in decimal degrees
- * @param {number} lon - Longitude in decimal degrees
- * @returns {string} ITU zone number (1-90) or "Unknown"
- *
- * @example
- * lookupITUZone(40.7128, -74.0060) // "8" (New York is in ITU zone 8)
- */
-function lookupITUZone(lat, lon) {
-  const pt = turf.point([lon, lat]);
-  for (const feature of ITUZoneFeat) {
-    if (turf.booleanPointInPolygon(pt, feature)) {
-      return String(feature.properties.itu_zone_number);
-    }
-  }
-  return "Unknown";
-}
-
-//format date
-// removed date input conversion helper (UI no longer supports date filtering)
-
-
-function getQueryParam(name) {
-  const urlParams = new URLSearchParams(window.location.search);
-  return urlParams.get(name);
-}
-
 var map = L.map('map').setView(CONFIG.map.initialView, CONFIG.map.initialZoom);
 
 
@@ -322,28 +166,6 @@ var layers = [];
 
 
 
-// helper funcs
-function frequencyToBand(freq) {
-  return CONFIG.freqToBand(freq);
-}
-function parseWsprTime(wsprTimeStr) {
-  const [datePart, timePart] = wsprTimeStr.split(' ');
-  const year = 2000 + parseInt(datePart.slice(0, 2), 10);
-  const month = parseInt(datePart.slice(2, 4), 10) - 1; // JS months: 0–11
-  const day = parseInt(datePart.slice(4, 6), 10);
-  const hour = parseInt(timePart.slice(0, 2), 10);
-  const minute = parseInt(timePart.slice(2, 4), 10);
-
-  const dt = new Date(Date.UTC(year, month, day, hour, minute));
-  return dt.toISOString().replace('T', ' ').slice(0, 19); // "YYYY-MM-DD HH:MM:SS"
-}
-function reverseWsprDate(dateStr) {
-  if (!dateStr || dateStr.length !== 6) return "Unknown date";
-  const year = 2000 + parseInt(dateStr.slice(0, 2), 10);
-  const month = dateStr.slice(2, 4);
-  const day = dateStr.slice(4, 6);
-  return `${year}-${month}-${day}`;
-}
 // band counts out for tables / charts
 let bandCountsOut = {};
 

--- a/static/js/table_ft.js
+++ b/static/js/table_ft.js
@@ -61,57 +61,6 @@ const call = CONFIG.station.callsign;
  * - North America: USA, Canada, Alaska, Mexico
  * - Oceania: Pacific islands
  */
-const regionZones = CONFIG.regionZones;
-  
-  /**
-   * Map CQ zone number to geographic region name.
-   *
-   * @param {number|string} cqZone - CQ zone number (1-40)
-   * @returns {string} Region name or "Unknown" if invalid zone
-   *
-   * @example
-   * getRegionFromCQ(5)  // "North America" (CQ zone 5 is eastern USA)
-   * getRegionFromCQ(14) // "Europe" (CQ zone 14 is Western Europe)
-   */
-  function getRegionFromCQ(cqZone) {
-    // Convert to number safely
-    const num = Number(cqZone);
-
-    // Validate zone number (1-40)
-    if (!num || num < 1 || num > 40) {
-      return "Unknown";
-    }
-
-    // Search for zone in region mapping
-    for (const [region, zones] of Object.entries(regionZones)) {
-      if (zones.includes(num)) return region;
-    }
-
-    // Zone not in any defined region
-    return "Unknown";
-  }
-
-
-  /**
-   * Parse spot timestamp from database format to JavaScript Date.
-   *
-   * Database stores dates as "YYMMDD HHMM" strings in UTC.
-   * Example: "260107 1430" = January 7, 2026 at 14:30 UTC
-   *
-   * @param {string} t - Timestamp string in "YYMMDD HHMM" format
-   * @returns {Date} JavaScript Date object in UTC
-   *
-   * @example
-   * parseTableTime("260107 1430") // Date object: 2026-01-07 14:30:00 UTC
-   */
-  function parseTableTime(t) {
-    const yy = Number(t.slice(0, 2)) + 2000;  // YY → YYYY
-    const mm = Number(t.slice(2, 4)) - 1;     // Month (0-11 for JS Date)
-    const dd = Number(t.slice(4, 6));         // Day
-    const HH = Number(t.slice(7, 9));         // Hour
-    const MM = Number(t.slice(9, 11));        // Minute
-    return new Date(Date.UTC(yy, mm, dd, HH, MM));
-  }
   
   async function loadSpots() {
     const mins = Number(document.getElementById("lastInterval").value) || CONFIG.defaults.lastInterval;

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,0 +1,263 @@
+// utils.js — Shared utility functions for the FRC Contesting web frontend.
+// Must be loaded after config.js and turf.min.js.
+
+// ── GeoJSON feature arrays ────────────────────────────────────────────────
+// Populated by the loader functions below. Used by the lookup functions and
+// by loadCqZones() in map_ft.js (which also handles Leaflet rendering).
+let countryFeat   = [];
+let continentFeat = [];
+let cqZoneFeat    = [];
+let ITUZoneFeat   = [];
+
+
+// ── GeoJSON data loaders ──────────────────────────────────────────────────
+
+/**
+ * Load country boundary polygons from GeoJSON file.
+ *
+ * Fetches the countries.geojson file (~14MB) containing boundary polygons
+ * for all world countries. Used for country-based filtering.
+ *
+ * @async
+ * @returns {Promise<void>}
+ */
+async function loadCountryPolygons() {
+  try {
+    const res = await fetch("js/countries.geojson");
+    const data = await res.json();
+    countryFeat = data.features;
+    console.log("Loaded", countryFeat.length, "country polygons");
+  } catch (err) {
+    console.error("Failed to load countries.geojson", err);
+  }
+}
+
+/**
+ * Load continent boundary polygons from GeoJSON file.
+ *
+ * Fetches the continents.geojson file containing polygons for
+ * the 7 continents. Used for continent-based filtering.
+ *
+ * @async
+ * @returns {Promise<void>}
+ */
+async function loadContinentPolygons() {
+  try {
+    const res = await fetch("js/continents.geojson");
+    const data = await res.json();
+    continentFeat = data.features;
+    console.log("Loaded", continentFeat.length, "continent polygons");
+  } catch (e) {
+    console.error("Failed to load continent GeoJSON", e);
+  }
+}
+
+/**
+ * Load ITU zone polygons from GeoJSON file.
+ *
+ * ITU zones are numbered 1-90 and defined by the International
+ * Telecommunication Union for amateur radio purposes.
+ *
+ * @async
+ * @returns {Promise<void>}
+ */
+async function loadITUZones() {
+  try {
+    const res = await fetch("js/ituzones.geojson");
+    const data = await res.json();
+    ITUZoneFeat = data.features;
+    console.log("Loaded", ITUZoneFeat.length, "ITU Zones");
+  } catch (e) {
+    console.error("Failed to load ITU Zones", e);
+  }
+}
+
+
+// ── Geographic lookups (Turf.js point-in-polygon) ─────────────────────────
+
+/**
+ * Lookup country name from geographic coordinates.
+ *
+ * @param {number} lat - Latitude in decimal degrees
+ * @param {number} lon - Longitude in decimal degrees
+ * @returns {string} Country name or "Unknown" if not found
+ *
+ * @example
+ * lookupCountry(40.7128, -74.0060) // "United States of America"
+ */
+function lookupCountry(lat, lon) {
+  const pt = turf.point([lon, lat]);
+  for (const feature of countryFeat) {
+    if (turf.booleanPointInPolygon(pt, feature)) {
+      return feature.properties.name || "Unknown";
+    }
+  }
+  return "Unknown";
+}
+
+/**
+ * Lookup continent name from geographic coordinates.
+ *
+ * @param {number} lat - Latitude in decimal degrees
+ * @param {number} lon - Longitude in decimal degrees
+ * @returns {string|null} Continent name or null if not found
+ *
+ * @example
+ * lookupContinent(40.7128, -74.0060) // "North America"
+ */
+function lookupContinent(lat, lon) {
+  const pt = turf.point([lon, lat]);
+  for (const feature of continentFeat) {
+    if (turf.booleanPointInPolygon(pt, feature)) {
+      return feature.properties.continent || "Unknown";
+    }
+  }
+  return null;
+}
+
+/**
+ * Lookup CQ zone number from geographic coordinates.
+ *
+ * CQ zones are numbered 1-40 and used for amateur radio contests
+ * and awards (e.g., Worked All Zones - WAZ).
+ *
+ * @param {number} lat - Latitude in decimal degrees
+ * @param {number} lon - Longitude in decimal degrees
+ * @returns {string} CQ zone number (1-40) or "Unknown"
+ *
+ * @example
+ * lookupCqZone(40.7128, -74.0060) // "5" (New York is in CQ zone 5)
+ */
+function lookupCqZone(lat, lon) {
+  const pt = turf.point([lon, lat]);
+  for (const feature of cqZoneFeat) {
+    if (turf.booleanPointInPolygon(pt, feature)) {
+      return String(feature.properties.cq_zone_number);
+    }
+  }
+  return "Unknown";
+}
+
+/**
+ * Lookup ITU zone number from geographic coordinates.
+ *
+ * @param {number} lat - Latitude in decimal degrees
+ * @param {number} lon - Longitude in decimal degrees
+ * @returns {string} ITU zone number (1-90) or "Unknown"
+ *
+ * @example
+ * lookupITUZone(40.7128, -74.0060) // "8" (New York is in ITU zone 8)
+ */
+function lookupITUZone(lat, lon) {
+  const pt = turf.point([lon, lat]);
+  for (const feature of ITUZoneFeat) {
+    if (turf.booleanPointInPolygon(pt, feature)) {
+      return String(feature.properties.itu_zone_number);
+    }
+  }
+  return "Unknown";
+}
+
+
+// ── Date / time helpers ───────────────────────────────────────────────────
+
+/**
+ * Parse a WSPR spot timestamp to an ISO-formatted string.
+ *
+ * The database stores timestamps as "YYMMDD HHMM" strings in UTC.
+ * Example: "260107 1430" → "2026-01-07 14:30:00"
+ *
+ * @param {string} wsprTimeStr - Timestamp in "YYMMDD HHMM" format
+ * @returns {string} ISO datetime string "YYYY-MM-DD HH:MM:SS"
+ */
+function parseWsprTime(wsprTimeStr) {
+  const [datePart, timePart] = wsprTimeStr.split(' ');
+  const year  = 2000 + parseInt(datePart.slice(0, 2), 10);
+  const month = parseInt(datePart.slice(2, 4), 10) - 1; // JS months: 0–11
+  const day   = parseInt(datePart.slice(4, 6), 10);
+  const hour  = parseInt(timePart.slice(0, 2), 10);
+  const minute = parseInt(timePart.slice(2, 4), 10);
+
+  const dt = new Date(Date.UTC(year, month, day, hour, minute));
+  return dt.toISOString().replace('T', ' ').slice(0, 19); // "YYYY-MM-DD HH:MM:SS"
+}
+
+/**
+ * Parse a spot timestamp from database format to a JavaScript Date object.
+ *
+ * The database stores timestamps as "YYMMDD HHMM" strings in UTC.
+ * Example: "260107 1430" → Date object at 2026-01-07 14:30:00 UTC
+ *
+ * @param {string} t - Timestamp in "YYMMDD HHMM" format
+ * @returns {Date} JavaScript Date object in UTC
+ */
+function parseTableTime(t) {
+  const yy = Number(t.slice(0, 2)) + 2000;  // YY → YYYY
+  const mm = Number(t.slice(2, 4)) - 1;     // Month (0-11 for JS Date)
+  const dd = Number(t.slice(4, 6));         // Day
+  const HH = Number(t.slice(7, 9));         // Hour
+  const MM = Number(t.slice(9, 11));        // Minute
+  return new Date(Date.UTC(yy, mm, dd, HH, MM));
+}
+
+/**
+ * Convert a 6-character WSPR date string to a readable "YYYY-MM-DD" string.
+ *
+ * @param {string} dateStr - Date in "YYMMDD" format
+ * @returns {string} Date string "YYYY-MM-DD" or "Unknown date" if invalid
+ */
+function reverseWsprDate(dateStr) {
+  if (!dateStr || dateStr.length !== 6) return "Unknown date";
+  const year  = 2000 + parseInt(dateStr.slice(0, 2), 10);
+  const month = dateStr.slice(2, 4);
+  const day   = dateStr.slice(4, 6);
+  return `${year}-${month}-${day}`;
+}
+
+
+// ── URL helper ────────────────────────────────────────────────────────────
+
+/**
+ * Read a single query parameter from the current page URL.
+ *
+ * @param {string} name - Parameter name
+ * @returns {string|null} Parameter value or null if not present
+ */
+function getQueryParam(name) {
+  const urlParams = new URLSearchParams(window.location.search);
+  return urlParams.get(name);
+}
+
+
+// ── Band / zone helpers ───────────────────────────────────────────────────
+
+/**
+ * Convert a frequency in MHz to its amateur radio band name.
+ * Delegates to CONFIG.freqToBand for the actual lookup table.
+ *
+ * @param {number} freq - Frequency in MHz
+ * @returns {string} Band name (e.g. "20m") or "unknown"
+ */
+function frequencyToBand(freq) {
+  return CONFIG.freqToBand(freq);
+}
+
+/**
+ * Map a CQ zone number to its geographic region name.
+ *
+ * @param {number|string} cqZone - CQ zone number (1-40)
+ * @returns {string} Region name or "Unknown" if zone is invalid/unmapped
+ *
+ * @example
+ * getRegionFromCQ(5)  // "North America"
+ * getRegionFromCQ(14) // "Europe"
+ */
+function getRegionFromCQ(cqZone) {
+  const num = Number(cqZone);
+  if (!num || num < 1 || num > 40) return "Unknown";
+
+  for (const [region, zones] of Object.entries(CONFIG.regionZones)) {
+    if (zones.includes(num)) return region;
+  }
+  return "Unknown";
+}

--- a/templates/index_ft.html
+++ b/templates/index_ft.html
@@ -148,6 +148,7 @@
 
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <script src="js/config.js"></script>
+  <script src="js/utils.js"></script>
   <script src="js/map_ft.js"></script>
   <script src="js/leaflet.extra-markers.min.js"></script>
   

--- a/templates/table_ft.html
+++ b/templates/table_ft.html
@@ -63,6 +63,7 @@
   <div id="spotsTableContainer" style="margin-top:20px;"></div>
 
   <script src="js/config.js"></script>
+  <script src="js/utils.js"></script>
   <script src="js/table_ft.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Creates `static/js/utils.js` containing all shared utility and helper functions
- Removes those functions from `map_ft.js` and `table_ft.js` to eliminate duplication
- Updates both HTML templates to load `utils.js` after `config.js` and before the app scripts

## Changes

| File | Change |
|---|---|
| `static/js/utils.js` | **New** — GeoJSON arrays, data loaders, geographic lookups, date/time helpers, band/zone helpers, URL helper |
| `static/js/map_ft.js` | Remove `countryFeat`/`continentFeat`/etc. declarations, `loadCountryPolygons`, `loadContinentPolygons`, `loadITUZones`, all four `lookup*` functions, `getQueryParam`, `frequencyToBand`, `parseWsprTime`, `reverseWsprDate` |
| `static/js/table_ft.js` | Remove `parseTableTime`, `getRegionFromCQ`, local `regionZones` alias |
| `templates/index_ft.html` | Add `utils.js` script tag |
| `templates/table_ft.html` | Add `utils.js` script tag |

> **Note:** `loadCqZones()` stays in `map_ft.js` because it also renders Leaflet layers and checks checkbox state. It still writes to the `cqZoneFeat` global declared in `utils.js`.

## Test plan

- [ ] Open map view — geographic lookups (country/continent/CQ/ITU filters) still work
- [ ] Open table view — region labels populate, time filtering works
- [ ] Check DevTools console for no `ReferenceError` on any moved function
- [ ] Toggle CQ zone overlay — `loadCqZones()` still populates `cqZoneFeat` and renders correctly

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)